### PR TITLE
fix(utils): missing patterntoroute function.

### DIFF
--- a/src/server/util.lua
+++ b/src/server/util.lua
@@ -141,3 +141,23 @@ function PromiseAsync:Series(tasks)
     end)
     return p
 end
+
+---@private
+--- Converts a string pattern "`/users/:id`" to an object for the Request class to use
+function PatternToRoute(input)
+    if input == "/" then input = "" end
+    local routeData = {
+        route = input,
+        params = {}
+    }
+    local matcher = input
+    for k,v in input:gmatch "/(:%w+)" do
+        local rawname = k:gsub(":", "")
+        table.insert(routeData.params, {
+            name = rawname
+        })
+        matcher, _ = matcher:gsub(k, "(%%w+)", 1)
+    end
+    routeData.route = matcher
+    return routeData
+end


### PR DESCRIPTION
Function recovered from a previous repo.

https://github.com/Cyntaax/fivem-http-wrapper/blob/823367da889afad7afefc28ad6bedc7991dda432/src/server/util/pattern.lua