### PR TITLE
Hotfix for some missing functions/variables

### DIFF
--- a/src/fxmanifest.lua
+++ b/src/fxmanifest.lua
@@ -1,5 +1,5 @@
 fx_version 'bodacious'
-
+game 'common'
 version  '_'
 
 server_scripts {

--- a/src/server/Router.lua
+++ b/src/server/Router.lua
@@ -25,7 +25,8 @@ function Router:Get(path, handler)
         path = parsed.route,
         handler = handler,
         pathData = parsed,
-        _path = parsed._route,
+        _path = parsed._path,
+        _route = parsed._route,
     })
 end
 
@@ -38,7 +39,8 @@ function Router:Post(path, handler)
         path = parsed.route,
         handler = handler,
         pathData = parsed,
-        _path = parsed._route,
+        _path = parsed._path,
+        _route = parsed._route,
     })
 end
 

--- a/src/server/Server.lua
+++ b/src/server/Server.lua
@@ -44,7 +44,7 @@ function Server.listen()
                         local request = Request.new(req)
                         if z.pathData then
                             for u,x in pairs(data) do
-                                request:SetParam(u, Util:DecodeURI(x))
+                                request:SetParam(u, decodeURI(x))
                             end
                         end
 

--- a/src/server/util.lua
+++ b/src/server/util.lua
@@ -141,3 +141,34 @@ function PromiseAsync:Series(tasks)
     end)
     return p
 end
+
+function PatternToRoute(input)
+    if input == "/" then input = "" end
+    local routeData = {
+        _route = input,
+        route = input,
+        _path = input,
+        path = input,
+        params = {}
+    }
+    local matcher = input
+    for k,v in input:gmatch "/(:%w+)" do
+        local rawname = k:gsub(":", "")
+        table.insert(routeData.params, {
+            name = rawname
+        })
+        matcher, _ = matcher:gsub(k, "(%%w+)", 1)
+    end
+    routeData._route = matcher
+    routeData.route = matcher
+    return routeData
+end
+
+
+local function decodeCharacter(code)
+    return string.char(tonumber(code, 16))
+end
+function decodeURI(s)
+    local str = s:gsub("+", " "):gsub('%%(%x%x)', decodeCharacter)
+    return str 
+end


### PR DESCRIPTION
This PR includes

- Added "game 'common'" into fxmanifest.lua. To fix that this resource can't start.
- Added the old function back ["PatternToRoute"](https://github.com/Cyntaax/fivem-http-wrapper/blob/823367da889afad7afefc28ad6bedc7991dda432/src/server/util/pattern.lua) but with some modifications that should fix the variable errors.
- Since function "Util:DecodeURI" doesn't exists. Added a function called "decodeURI".